### PR TITLE
fix ci pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,4 +9,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
     - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,3 +61,4 @@ repos:
       - id: docformatter
         additional_dependencies: [tomli]
         args: [--in-place, --config, ./pyproject.toml]
+        language_version: python3.10

--- a/docker/airflow/Dockerfile
+++ b/docker/airflow/Dockerfile
@@ -2,12 +2,8 @@ FROM apache/airflow:3.1.3-python3.10
 # FROM --platform=linux/amd64 apache/airflow:3.0.0-python3.9
 
 USER root
-RUN apt-get update && apt-get install -y curl wget vim procps less
-
-# TODO: Try using https://download.java.net/java/GA/jdk24.0.1/24a58e0e276943138bf3e963e6291ac2/9/GPL/openjdk-24.0.1_linux-x64_bin.tar.gz
-RUN wget --no-verbose -O openjdk-11.tar.gz https://builds.openlogic.com/downloadJDK/openlogic-openjdk/11.0.11%2B9/openlogic-openjdk-11.0.11%2B9-linux-x64.tar.gz
-RUN tar -xzf openjdk-11.tar.gz --one-top-level=openjdk-11 --strip-components 1 -C /usr/local
-ENV JAVA_HOME=/usr/local/openjdk-11
+RUN apt-get update && apt-get install -y curl wget vim procps less default-jdk
+ENV JAVA_HOME=/usr/lib/jvm/default-java
 # ENV SPARK_WORKLOAD=submit
 
 ENV SPARK_VERSION=3.5.7 \


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add Python 3.10 language version specification to docformatter hook

- Ensures docformatter pre-commit hook runs with correct Python version


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["docformatter hook config"] -- "add language_version" --> B["Python 3.10 specification"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pre-commit-config.yaml</strong><dd><code>Add Python 3.10 language version to docformatter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pre-commit-config.yaml

<ul><li>Added <code>language_version: python3.10</code> to the docformatter hook <br>configuration<br> <li> Specifies the Python version that the docformatter pre-commit hook <br>should use</ul>


</details>


  </td>
  <td><a href="https://github.com/aliavni/docker/pull/22/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

